### PR TITLE
Vector Quantization as a Pytorch Function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ nosetests.xml
 coverage.xml
 *.cover
 .hypothesis/
+.pytest_cache/
 
 # Translations
 *.mo

--- a/functions.py
+++ b/functions.py
@@ -59,3 +59,7 @@ class VectorQuantizationStraightThrough(Function):
             grad_codebook.index_add_(0, indices, grad_output_flatten)
 
         return (grad_inputs, grad_codebook)
+
+vq = VectorQuantization.apply
+vq_st = VectorQuantizationStraightThrough.apply
+__all__ = [vq, vq_st]

--- a/functions.py
+++ b/functions.py
@@ -35,6 +35,7 @@ class VectorQuantizationStraightThrough(Function):
         indices = vq(inputs, codebook)
         indices_flatten = indices.view(-1)
         ctx.save_for_backward(indices_flatten, codebook)
+        ctx.mark_non_differentiable(indices_flatten)
 
         codes_flatten = torch.index_select(codebook, dim=0,
             index=indices_flatten)

--- a/functions.py
+++ b/functions.py
@@ -54,7 +54,8 @@ class VectorQuantizationStraightThrough(Function):
             indices, codebook = ctx.saved_tensors
             embedding_size = codebook.size(1)
 
-            grad_output_flatten = grad_output.view(-1, embedding_size)
+            grad_output_flatten = (grad_output.contiguous()
+                                              .view(-1, embedding_size))
             grad_codebook = torch.zeros_like(codebook)
             grad_codebook.index_add_(0, indices, grad_output_flatten)
 

--- a/functions.py
+++ b/functions.py
@@ -1,0 +1,61 @@
+import torch
+from torch.autograd import Function
+
+class VectorQuantization(Function):
+    @staticmethod
+    def forward(ctx, inputs, codebook):
+        with torch.no_grad():
+            embedding_size = codebook.size(1)
+            inputs_size = inputs.size()
+            inputs_flatten = inputs.view(-1, embedding_size)
+
+            codebook_sqr = torch.sum(codebook ** 2, dim=1)
+            inputs_sqr = torch.sum(inputs_flatten ** 2, dim=1, keepdim=True)
+
+            # Compute the distances to the codebook
+            distances = torch.addmm(codebook_sqr + inputs_sqr,
+                inputs_flatten, codebook.t(), alpha=-2.0, beta=1.0)
+
+            _, indices_flatten = torch.min(distances, dim=1)
+            indices = indices_flatten.view(*inputs_size[:-1])
+            ctx.mark_non_differentiable(indices)
+
+            return indices
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        raise RuntimeError('Trying to call `.grad()` on graph containing '
+            '`VectorQuantization`. The function `VectorQuantization` '
+            'is not differentiable. Use `VectorQuantizationStraightThrough` '
+            'if you want a straight-through estimator of the gradient.')
+
+class VectorQuantizationStraightThrough(Function):
+    @staticmethod
+    def forward(ctx, inputs, codebook):
+        indices = vq(inputs, codebook)
+        indices_flatten = indices.view(-1)
+        ctx.save_for_backward(indices_flatten, codebook)
+
+        codes_flatten = torch.index_select(codebook, dim=0,
+            index=indices_flatten)
+        codes = codes_flatten.view_as(inputs)
+
+        return codes
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        grad_inputs, grad_codebook = None, None
+
+        if ctx.needs_input_grad[0]:
+            # Straight-through estimator
+            grad_inputs = grad_output.clone()
+        if ctx.needs_input_grad[1]:
+            # Gradient wrt. the codebook
+            indices, codebook = ctx.saved_tensors
+            embedding_size = codebook.size(1)
+
+            grad_output_flatten = grad_output.view(-1, embedding_size)
+            grad_codebook = torch.zeros_like(codebook)
+            grad_codebook.index_add_(0, indices, grad_output_flatten)
+
+        return (grad_inputs, grad_codebook)

--- a/functions.py
+++ b/functions.py
@@ -40,10 +40,10 @@ class VectorQuantizationStraightThrough(Function):
             index=indices_flatten)
         codes = codes_flatten.view_as(inputs)
 
-        return codes
+        return (codes, indices_flatten)
 
     @staticmethod
-    def backward(ctx, grad_output):
+    def backward(ctx, grad_output, grad_indices):
         grad_inputs, grad_codebook = None, None
 
         if ctx.needs_input_grad[0]:

--- a/miniimagenet_pixelcnn_prior.py
+++ b/miniimagenet_pixelcnn_prior.py
@@ -14,7 +14,7 @@ def train(data_loader, model, prior, optimizer, args, writer):
     for images, labels in data_loader:
         with torch.no_grad():
             images = images.to(args.device)
-            latents, _ = model.encode(images)
+            latents = model.encode(images)
             latents = latents.detach()
 
         labels = labels.to(args.device)
@@ -39,7 +39,7 @@ def test(data_loader, model, prior, args, writer):
             images = images.to(args.device)
             labels = labels.to(args.device)
 
-            latents, _ = model.encode(images)
+            latents = model.encode(images)
             latents = latents.detach()
             logits = prior(latents, labels)
             logits = logits.permute(0, 2, 3, 1).contiguous()

--- a/miniimagenet_pixelcnn_prior.py
+++ b/miniimagenet_pixelcnn_prior.py
@@ -5,7 +5,7 @@ import json
 from torchvision import transforms
 from torchvision.utils import save_image, make_grid
 
-from modules import AutoEncoder, GatedPixelCNN
+from modules import VectorQuantizedVAE, GatedPixelCNN
 from datasets import MiniImagenet
 
 from tensorboardX import SummaryWriter
@@ -89,7 +89,7 @@ def main(args):
     fixed_grid = make_grid(fixed_images, nrow=8, range=(-1, 1), normalize=True)
     writer.add_image('original', fixed_grid, 0)
 
-    model = AutoEncoder(3, args.hidden_size_vae, args.k).to(args.device)
+    model = VectorQuantizedVAE(3, args.hidden_size_vae, args.k).to(args.device)
     with open(args.model, 'rb') as f:
         state_dict = torch.load(f)
         model.load_state_dict(state_dict)

--- a/miniimagenet_vqvae.py
+++ b/miniimagenet_vqvae.py
@@ -24,7 +24,7 @@ def train(data_loader, model, optimizer, args, writer):
         z_e_x.backward(z_q_x.grad, retain_graph=True)
 
         # Vector quantization objective
-        model.embedding.zero_grad()
+        model.codebook.embedding.zero_grad()
         loss_vq = F.mse_loss(z_q_x, z_e_x.detach())
         loss_vq.backward(retain_graph=True)
 

--- a/miniimagenet_vqvae.py
+++ b/miniimagenet_vqvae.py
@@ -4,7 +4,7 @@ import torch.nn.functional as F
 from torchvision import transforms
 from torchvision.utils import save_image, make_grid
 
-from modules import AutoEncoder, to_scalar
+from modules import VectorQuantizedVAE, to_scalar
 from datasets import MiniImagenet
 
 from tensorboardX import SummaryWriter
@@ -95,7 +95,7 @@ def main(args):
     fixed_grid = make_grid(fixed_images, nrow=8, range=(-1, 1), normalize=True)
     writer.add_image('original', fixed_grid, 0)
 
-    model = AutoEncoder(3, args.hidden_size, args.k).to(args.device)
+    model = VectorQuantizedVAE(3, args.hidden_size, args.k).to(args.device)
     optimizer = torch.optim.Adam(model.parameters(), lr=args.lr)
 
     # Generate the samples first once

--- a/modules.py
+++ b/modules.py
@@ -81,7 +81,7 @@ class VQEmbedding(nn.Module):
     def straight_through(self, z_e_x):
         z_e_x_ = z_e_x.permute(0, 2, 3, 1).contiguous()
         z_q_x_ = vq_st(z_e_x_, self.embedding.weight)
-        z_q_x = z_q_x_.permute(0, 3, 1, 2)
+        z_q_x = z_q_x_.permute(0, 3, 1, 2).contiguous()
         return z_q_x
 
 

--- a/modules.py
+++ b/modules.py
@@ -4,6 +4,7 @@ import torch.nn.functional as F
 from torch.distributions.normal import Normal
 from torch.distributions import kl_divergence
 
+from functions import vq, vq_st
 
 def to_scalar(arr):
     if type(arr) == list:
@@ -73,17 +74,15 @@ class VQEmbedding(nn.Module):
         self.embedding.weight.data.uniform_(-1./K, 1./K)
 
     def forward(self, z_e_x):
-        # z_e_x - (B, D, H, W)
-        # emb   - (K, D)
-
-        emb = self.embedding.weight
-        dists = torch.pow(
-            z_e_x.unsqueeze(1) - emb[None, :, :, None, None],
-            2
-        ).sum(2)
-
-        latents = dists.min(1)[1]
+        z_e_x_ = z_e_x.permute(0, 2, 3, 1).contiguous()
+        latents = vq(z_e_x_, self.embedding.weight)
         return latents
+
+    def straight_through(self, z_e_x):
+        z_e_x_ = z_e_x.permute(0, 2, 3, 1).contiguous()
+        z_q_x_ = vq_st(z_e_x_, self.embedding.weight)
+        z_q_x = z_q_x_.permute(0, 3, 1, 2)
+        return z_q_x
 
 
 class ResBlock(nn.Module):
@@ -132,16 +131,17 @@ class VectorQuantizedVAE(nn.Module):
     def encode(self, x):
         z_e_x = self.encoder(x)
         latents = self.codebook(z_e_x)
-        return latents, z_e_x
+        return latents
 
     def decode(self, latents):
         z_q_x = self.codebook.embedding(latents).permute(0, 3, 1, 2)  # (B, D, H, W)
         x_tilde = self.decoder(z_q_x)
-        return x_tilde, z_q_x
+        return x_tilde
 
     def forward(self, x):
-        latents, z_e_x = self.encode(x)
-        x_tilde, z_q_x = self.decode(latents)
+        z_e_x = self.encoder(x)
+        z_q_x = self.codebook.straight_through(z_e_x)
+        x_tilde = self.decoder(z_q_x)
         return x_tilde, z_e_x, z_q_x
 
 

--- a/pixelcnn_prior.py
+++ b/pixelcnn_prior.py
@@ -118,7 +118,7 @@ def generate_samples():
     label = label.to(device=DEVICE, dtype=torch.int64)
 
     latents = model.generate(label, shape=LATENT_SHAPE, batch_size=100)
-    x_tilde, _ = autoencoder.decode(latents)
+    x_tilde = autoencoder.decode(latents)
     images = (x_tilde.cpu().data + 1) / 2
 
     save_image(

--- a/test_functions.py
+++ b/test_functions.py
@@ -29,16 +29,20 @@ def test_vq():
 def test_vq_st_shape():
     inputs = torch.rand((2, 3, 5, 7), dtype=torch.float32, requires_grad=True)
     codebook = torch.rand((11, 7), dtype=torch.float32, requires_grad=True)
-    codes = vq_st(inputs, codebook)
+    codes, indices = vq_st(inputs, codebook)
 
     assert codes.size() == (2, 3, 5, 7)
     assert codes.requires_grad
     assert codes.dtype == torch.float32
 
+    assert indices.size() == (2 * 3 * 5,)
+    assert not indices.requires_grad
+    assert indices.dtype == torch.int64
+
 def test_vq_st_gradient1():
     inputs = torch.rand((2, 3, 5, 7), dtype=torch.float32, requires_grad=True)
     codebook = torch.rand((11, 7), dtype=torch.float32, requires_grad=True)
-    codes = vq_st(inputs, codebook)
+    codes, _ = vq_st(inputs, codebook)
 
     grad_output = torch.rand((2, 3, 5, 7))
     grad_inputs, = torch.autograd.grad(codes, inputs,
@@ -51,7 +55,7 @@ def test_vq_st_gradient1():
 def test_vq_st_gradient2():
     inputs = torch.rand((2, 3, 5, 7), dtype=torch.float32, requires_grad=True)
     codebook = torch.rand((11, 7), dtype=torch.float32, requires_grad=True)
-    codes = vq_st(inputs, codebook)
+    codes, _ = vq_st(inputs, codebook)
 
     indices = vq(inputs, codebook)
     codes_torch = torch.embedding(codebook, indices, padding_idx=-1,

--- a/test_functions.py
+++ b/test_functions.py
@@ -1,0 +1,68 @@
+import pytest
+
+import numpy as np
+import torch
+
+from functions import vq, vq_st
+
+def test_vq_shape():
+    inputs = torch.rand((2, 3, 5, 7), dtype=torch.float32, requires_grad=True)
+    codebook = torch.rand((11, 7), dtype=torch.float32, requires_grad=True)
+    indices = vq(inputs, codebook)
+
+    assert indices.size() == (2, 3, 5)
+    assert not indices.requires_grad
+    assert indices.dtype == torch.int64
+
+def test_vq():
+    inputs = torch.rand((2, 3, 5, 7), dtype=torch.float32, requires_grad=True)
+    codebook = torch.rand((11, 7), dtype=torch.float32, requires_grad=True)
+    indices = vq(inputs, codebook)
+
+    differences = inputs.unsqueeze(3) - codebook
+    distances = torch.norm(differences, p=2, dim=4)
+
+    _, indices_torch = torch.min(distances, dim=3)
+
+    assert np.allclose(indices.numpy(), indices_torch.numpy())
+
+def test_vq_st_shape():
+    inputs = torch.rand((2, 3, 5, 7), dtype=torch.float32, requires_grad=True)
+    codebook = torch.rand((11, 7), dtype=torch.float32, requires_grad=True)
+    codes = vq_st(inputs, codebook)
+
+    assert codes.size() == (2, 3, 5, 7)
+    assert codes.requires_grad
+    assert codes.dtype == torch.float32
+
+def test_vq_st_gradient1():
+    inputs = torch.rand((2, 3, 5, 7), dtype=torch.float32, requires_grad=True)
+    codebook = torch.rand((11, 7), dtype=torch.float32, requires_grad=True)
+    codes = vq_st(inputs, codebook)
+
+    grad_output = torch.rand((2, 3, 5, 7))
+    grad_inputs, = torch.autograd.grad(codes, inputs,
+        grad_outputs=[grad_output])
+
+    # Straight-through estimator
+    assert grad_inputs.size() == (2, 3, 5, 7)
+    assert np.allclose(grad_output.numpy(), grad_inputs.numpy())
+
+def test_vq_st_gradient2():
+    inputs = torch.rand((2, 3, 5, 7), dtype=torch.float32, requires_grad=True)
+    codebook = torch.rand((11, 7), dtype=torch.float32, requires_grad=True)
+    codes = vq_st(inputs, codebook)
+
+    indices = vq(inputs, codebook)
+    codes_torch = torch.embedding(codebook, indices, padding_idx=-1,
+        scale_grad_by_freq=False, sparse=False)
+
+    grad_output = torch.rand((2, 3, 5, 7), dtype=torch.float32)
+    grad_codebook, = torch.autograd.grad(codes, codebook,
+        grad_outputs=[grad_output])
+    grad_codebook_torch, = torch.autograd.grad(codes_torch, codebook,
+        grad_outputs=[grad_output])
+
+    # Gradient is the same as torch.embedding function
+    assert grad_codebook.size() == (11, 7)
+    assert np.allclose(grad_codebook.numpy(), grad_codebook_torch.numpy())


### PR DESCRIPTION
 - Add `VectorQuantization` and `VectorQuantizationStraightThrough` Pytorch functions (with aliases `vq` and `vq_st`)
 - Vector quantization now requires less memory
 - Add tests for these functions
 - Leads to a ~3x speedup on Mini-Imagenet